### PR TITLE
add fftw3 library

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -22,9 +24,14 @@ libblas:
 - 3.8 *netlib
 liblapack:
 - 3.8 *netlib
+pin_run_as_build:
+  fftw:
+    max_pin: x
 target_platform:
 - linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
   - fortran_compiler_version
+- - cdt_name
+  - docker_image

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -12,6 +12,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '11'
+fftw:
+- '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
@@ -22,6 +24,9 @@ liblapack:
 - 3.8 *netlib
 macos_machine:
 - x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  fftw:
+    max_pin: x
 target_platform:
 - osx-64
 zip_keys:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/Darwin-x86-64-conda.ssmp
+++ b/recipe/Darwin-x86-64-conda.ssmp
@@ -18,9 +18,9 @@
 CPP         = $(CC)-cpp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 AR         += -r
-DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE
+DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3
 FCFLAGS     = $(FFLAGS) -ffree-form $(DFLAGS) -fbacktrace -fopenmp
-LIBS        = -framework Accelerate
+LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp
 
 # Using LDFLAGS_LD since cp2k passes the LDFLAGS directly to the linker
 LDFLAGS     = $(LDFLAGS_LD) -lgfortran -lc -lgomp

--- a/recipe/Darwin-x86-64-conda.ssmp
+++ b/recipe/Darwin-x86-64-conda.ssmp
@@ -19,7 +19,7 @@ CPP         = $(CC)-cpp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 AR         += -r
 DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3
-FCFLAGS     = $(FFLAGS) -ffree-form $(DFLAGS) -fbacktrace -fopenmp
+FCFLAGS     = $(FFLAGS) -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
 LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp
 
 # Using LDFLAGS_LD since cp2k passes the LDFLAGS directly to the linker

--- a/recipe/Linux-x86-64-conda.ssmp
+++ b/recipe/Linux-x86-64-conda.ssmp
@@ -18,8 +18,9 @@
 
 AR          = $(GCC_AR) -r
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
+DFLAGS      = -D__FFTW3
 FCFLAGS     = $(FFLAGS) -ffree-form -fopenmp
-LIBS        = -llapack -lblas
+LIBS        = -llapack -lblas -fftw3 -lfftw3_omp
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)
 LDFLAGS    += -fopenmp -Wl,-lgomp

--- a/recipe/Linux-x86-64-conda.ssmp
+++ b/recipe/Linux-x86-64-conda.ssmp
@@ -20,7 +20,7 @@ AR          = $(GCC_AR) -r
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 DFLAGS      = -D__FFTW3
 FCFLAGS     = $(FFLAGS) -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = -llapack -lblas -fftw3 -lfftw3_omp
+LIBS        = -llapack -lblas -lfftw3 -lfftw3_omp
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)
 LDFLAGS    += -fopenmp -Wl,-lgomp

--- a/recipe/Linux-x86-64-conda.ssmp
+++ b/recipe/Linux-x86-64-conda.ssmp
@@ -19,7 +19,7 @@
 AR          = $(GCC_AR) -r
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 DFLAGS      = -D__FFTW3
-FCFLAGS     = $(FFLAGS) -ffree-form -fopenmp
+FCFLAGS     = $(FFLAGS) -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
 LIBS        = -llapack -lblas -fftw3 -lfftw3_omp
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - macosxtest.patch  # [osx]
 
 build:
-  number: 3
+  number: 4
   skip: True  # [not (linux or osx) ]
 
 requirements:
@@ -32,6 +32,7 @@ requirements:
   host:
     - libblas
     - liblapack
+    - fftw
 
 test:
   commands:


### PR DESCRIPTION
When running the old binary on MacOS, I'm getting

WARNING : FFT library FFTW3 is not available  Trying FFTSG as a default

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
