### PR TITLE
osx: move away from accelerate framework

### DIFF
--- a/recipe/Darwin-x86-64-conda.ssmp
+++ b/recipe/Darwin-x86-64-conda.ssmp
@@ -20,7 +20,7 @@ CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 AR         += -r
 DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3
 FCFLAGS     = $(FFLAGS) -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp
+LIBS        = -llapack -lblas -lfftw3 -lfftw3_omp
 
 # Using LDFLAGS_LD since cp2k passes the LDFLAGS directly to the linker
 LDFLAGS     = $(LDFLAGS_LD) -lgfortran -lc -lgomp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - macosxtest.patch  # [osx]
 
 build:
-  number: 4
+  number: 5
   skip: True  # [not (linux or osx) ]
 
 requirements:


### PR DESCRIPTION
fix #15

move to standard libblas/liblapack since the default threading behavior
(although controllable via the VECLIB_MAXIMUM_THREADS environemnt
variable) slows down execution.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
