### PR TITLE
remove debug symbols again

### DIFF
--- a/recipe/Darwin-x86-64-conda.psmp
+++ b/recipe/Darwin-x86-64-conda.psmp
@@ -17,10 +17,10 @@ FC          = mpifort
 CPP         = $(CC)-cpp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 # default -std=c99 complains about missing declaration of clock_gettime
-CFLAGS     += -fopenmp -g -std=c11
+CFLAGS     += -fopenmp -std=c11
 AR         += -r
 DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3 -D__LIBXSMM -D__parallel -D__SCALAPACK
-FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp -g $(DFLAGS)
+FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
 LIBS        = = -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt
 
 # need to use mpifort also for linking

--- a/recipe/Darwin-x86-64-conda.ssmp
+++ b/recipe/Darwin-x86-64-conda.ssmp
@@ -17,10 +17,10 @@ FC          = x86_64-apple-darwin13.4.0-gfortran
 CPP         = $(CC)-cpp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 # default -std=c99 complains about missing declaration of clock_gettime
-CFLAGS     += -fopenmp -g -std=c11
+CFLAGS     += -fopenmp -std=c11
 AR         += -r
 DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3 -D__LIBXSMM
-FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp -g $(DFLAGS)
+FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
 LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lrt
 
 # Using LDFLAGS_LD since cp2k passes the LDFLAGS directly to the linker

--- a/recipe/Linux-x86-64-conda.psmp
+++ b/recipe/Linux-x86-64-conda.psmp
@@ -16,10 +16,10 @@
 
 FC          = mpifort
 AR          = $(GCC_AR) -r
-CFLAGS     += -fopenmp -g
+CFLAGS     += -fopenmp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 DFLAGS      = -D__FFTW3 -D__LIBXSMM -D__parallel -D__SCALAPACK
-FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp -g $(DFLAGS)
+FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
 LIBS        = -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)

--- a/recipe/Linux-x86-64-conda.ssmp
+++ b/recipe/Linux-x86-64-conda.ssmp
@@ -17,9 +17,9 @@
 AR          = $(GCC_AR) -r
 FC          = x86_64-conda-linux-gnu-gfortran
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
-CFLAGS     += -fopenmp -g
+CFLAGS     += -fopenmp
 DFLAGS      = -D__FFTW3 -D__LIBXSMM
-FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp -g $(DFLAGS)
+FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
 LIBS        = -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lrt
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -35,3 +35,6 @@ cd ${SRC_DIR}
 mkdir -p ${PREFIX}/bin
 cp exe/${ARCH}/cp2k.${VERSION} ${PREFIX}/bin/cp2k.${VERSION}
 cp exe/${ARCH}/cp2k_shell.${VERSION} ${PREFIX}/bin/cp2k_shell.${VERSION}
+
+exe_size=`du -sh exe/${ARCH}/cp2k.${VERSION}`
+echo "Executable size: $exe_size"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # Define build matrix for MPI vs. non-mpi
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
-{% set build = 1 %}
+{% set build = 2 %}
 {% if mpi == 'nompi' %}
 # prioritize 'nompi' variant via build number
 {% set build = build + 1000 %}


### PR DESCRIPTION
While having debug symbols would have been useful for debug purposes, it
bloats the size of the package from ~22MB to ~84MB and the size of the
executable from ~38MB to ~138MB.

This can be problematic in contexts like the Quantum Mobile.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
