### PR TITLE
use openmp variant of openblas

### DIFF
--- a/recipe/Darwin-x86-64-conda.psmp
+++ b/recipe/Darwin-x86-64-conda.psmp
@@ -21,7 +21,7 @@ CFLAGS     += -fopenmp -std=c11
 AR         += -r
 DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3 -D__LIBXSMM -D__parallel -D__SCALAPACK -D__SPGLIB
 FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = = -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt -lsymspg
+LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt -lsymspg
 
 # need to use mpifort also for linking
 LD          = $(FC)

--- a/recipe/Linux-x86-64-conda.psmp
+++ b/recipe/Linux-x86-64-conda.psmp
@@ -20,7 +20,7 @@ CFLAGS     += -fopenmp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 DFLAGS      = -D__FFTW3 -D__LIBXSMM -D__parallel -D__SCALAPACK -D__SPGLIB
 FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt -lsymspg
+LIBS        = -lopenblas -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt -lsymspg
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)
 LDFLAGS    += -fopenmp -Wl,-lgomp

--- a/recipe/Linux-x86-64-conda.ssmp
+++ b/recipe/Linux-x86-64-conda.ssmp
@@ -20,7 +20,7 @@ CFLAGS     += -fopenmp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 DFLAGS      = -D__FFTW3 -D__LIBXSMM -D__SPGLIB
 FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lrt -lsymspg
+LIBS        = -lopenblas -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lrt -lsymspg
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)
 LDFLAGS    += -fopenmp -Wl,-lgomp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # Define build matrix for MPI vs. non-mpi
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
-{% set build = 3 %}
+{% set build = 4 %}
 {% if mpi == 'nompi' %}
 # prioritize 'nompi' variant via build number
 {% set build = build + 1000 %}
@@ -44,7 +44,8 @@ requirements:
   host:
     - {{ mpi }}  # [mpi != 'nompi']
     - scalapack  # [mpi != 'nompi']
-    - libblas
+    - libblas  # [osx]
+    - openblas * *openmp*  # [linux]
     - liblapack
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
@@ -55,6 +56,8 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - scalapack  # [mpi != 'nompi']
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
+    - libblas * *openblas  # [linux]
+    - openblas * *openmp*  # [linux]
 
 test:
   commands:


### PR DESCRIPTION
fix #30

the `libblas` dependency resolved to the openblas variant so far,
but the non-openmp variant of openblas.

this resulted in the following warnings when running with more than
one openmp thread:

    OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.

Following the docs we're now selecting the openmp-enabled variant of
openblas.

[1] https://conda-forge.org/docs/maintainer/knowledge_base.html?highlight=mesa#blas

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
