### PR TITLE
enable libxc for linux

### DIFF
--- a/.ci_support/linux_64_mpinompi.yaml
+++ b/.ci_support/linux_64_mpinompi.yaml
@@ -20,8 +20,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
-libblas:
-- 3.8 *netlib
 liblapack:
 - 3.8 *netlib
 mpi:

--- a/.ci_support/linux_64_mpiopenmpi.yaml
+++ b/.ci_support/linux_64_mpiopenmpi.yaml
@@ -20,8 +20,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '9'
-libblas:
-- 3.8 *netlib
 liblapack:
 - 3.8 *netlib
 mpi:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -52,11 +52,11 @@ if [ -z "${DOCKER_IMAGE}" ]; then
         echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
         DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
         if [ "${DOCKER_IMAGE}" = "" ]; then
-            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
-            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+            echo "No docker_image entry found in ${CONFIG}. Falling back to quay.io/condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="quay.io/condaforge/linux-anvil-comp7"
         fi
     else
-        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 quay.io/condaforge/linux-anvil-comp7 )"
     fi
 fi
 

--- a/recipe/Darwin-x86-64-conda.psmp
+++ b/recipe/Darwin-x86-64-conda.psmp
@@ -19,10 +19,9 @@ CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 # default -std=c99 complains about missing declaration of clock_gettime
 CFLAGS     += -fopenmp -std=c11
 AR         += -r
-DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3 -D__LIBXSMM -D__parallel -D__SCALAPACK -D__SPGLIB
+DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3 -D__LIBXSMM -D__parallel -D__SCALAPACK -D__SPGLIB -D__LIBXC
 FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt -lsymspg
-
+LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt -lsymspg -lxcf03 -lxc
 # need to use mpifort also for linking
 LD          = $(FC)
 LDFLAGS    += -lgfortran -lc -lgomp

--- a/recipe/Darwin-x86-64-conda.ssmp
+++ b/recipe/Darwin-x86-64-conda.ssmp
@@ -19,9 +19,8 @@ CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
 # default -std=c99 complains about missing declaration of clock_gettime
 CFLAGS     += -fopenmp -std=c11
 AR         += -r
-DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3 -D__LIBXSMM -D__SPGLIB
+DFLAGS      = -D__NO_STATM_ACCESS -D__ACCELERATE -D__FFTW3 -D__LIBXSMM -D__SPGLIB -D__LIBXC
 FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lrt -lsymspg
-
+LIBS        = -framework Accelerate -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lrt -lsymspg -lxcf03 -lxc
 # Using LDFLAGS_LD since cp2k passes the LDFLAGS directly to the linker
 LDFLAGS     = $(LDFLAGS_LD) -lgfortran -lc -lgomp

--- a/recipe/Linux-x86-64-conda.psmp
+++ b/recipe/Linux-x86-64-conda.psmp
@@ -18,9 +18,9 @@ FC          = mpifort
 AR          = $(GCC_AR) -r
 CFLAGS     += -fopenmp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
-DFLAGS      = -D__FFTW3 -D__LIBXSMM -D__parallel -D__SCALAPACK -D__SPGLIB
+DFLAGS      = -D__FFTW3 -D__LIBXSMM -D__parallel -D__SCALAPACK -D__SPGLIB -D__LIBXC
 FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = -lopenblas -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt -lsymspg
+LIBS        = -lopenblas -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lscalapack -lrt -lsymspg -lxcf03 -lxc
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)
 LDFLAGS    += -fopenmp -Wl,-lgomp

--- a/recipe/Linux-x86-64-conda.ssmp
+++ b/recipe/Linux-x86-64-conda.ssmp
@@ -18,9 +18,9 @@ AR          = $(GCC_AR) -r
 FC          = x86_64-conda-linux-gnu-gfortran
 CFLAGS     += -fopenmp
 CPPFLAGS   += -C -P -traditional -D__NO_IPI_DRIVER -nostdinc
-DFLAGS      = -D__FFTW3 -D__LIBXSMM -D__SPGLIB
+DFLAGS      = -D__FFTW3 -D__LIBXSMM -D__SPGLIB -D__LIBXC
 FCFLAGS     = $(FFLAGS) -I $(PREFIX)/include -fbacktrace -ffree-form -fimplicit-none -std=f2008 -fopenmp $(DFLAGS)
-LIBS        = -lopenblas -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lrt -lsymspg
+LIBS        = -lopenblas -llapack -lblas -lfftw3 -lfftw3_omp -lxsmmf -lxsmm -ldl -lrt -lsymspg -lxcf03 -lxc
 # Since LDFLAGS_LD is missing, we are linking using gfortran (which can use LDFLAGS)
 LD          = $(FC)
 LDFLAGS    += -fopenmp -Wl,-lgomp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # Define build matrix for MPI vs. non-mpi
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
-{% set build = 4 %}
+{% set build = 5 %}
 {% if mpi == 'nompi' %}
 # prioritize 'nompi' variant via build number
 {% set build = build + 1000 %}
@@ -52,6 +52,7 @@ requirements:
     - libxsmm
     - fftw
     - spglib
+    - libxc ==4.3.*
   run:
     - {{ mpi }}  # [mpi != 'nompi']
     - scalapack  # [mpi != 'nompi']


### PR DESCRIPTION
Enable libxc support for linux (requires libxc 4.3.x).
OSX version is available from libxc 5.1 onwards, which will be supported
in cp2k 8.2

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
