### PR TITLE
Removed python pin from package

### DIFF
--- a/.ci_support/linux_64_blas_implmklmpinompi.yaml
+++ b/.ci_support/linux_64_blas_implmklmpinompi.yaml
@@ -32,8 +32,6 @@ mpich:
 - '4'
 openmpi:
 - '4'
-target_platform:
-- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_blas_implmklmpiopenmpi.yaml
+++ b/.ci_support/linux_64_blas_implmklmpiopenmpi.yaml
@@ -32,8 +32,6 @@ mpich:
 - '4'
 openmpi:
 - '4'
-target_platform:
-- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_blas_implopenblasmpinompi.yaml
+++ b/.ci_support/linux_64_blas_implopenblasmpinompi.yaml
@@ -32,8 +32,6 @@ mpich:
 - '4'
 openmpi:
 - '4'
-target_platform:
-- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/linux_64_blas_implopenblasmpiopenmpi.yaml
+++ b/.ci_support/linux_64_blas_implopenblasmpiopenmpi.yaml
@@ -32,8 +32,6 @@ mpich:
 - '4'
 openmpi:
 - '4'
-target_platform:
-- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/README.md
+++ b/README.md
@@ -22,51 +22,11 @@ Current build status
 ====================
 
 
-<table>
-    
-  <tr>
-    <td>Azure</td>
+<table><tr><td>All platforms:</td>
     <td>
-      <details>
-        <summary>
-          <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7705&branchName=main">
-            <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cp2k-feedstock?branchName=main">
-          </a>
-        </summary>
-        <table>
-          <thead><tr><th>Variant</th><th>Status</th></tr></thead>
-          <tbody><tr>
-              <td>linux_64_blas_implmklmpinompi</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7705&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cp2k-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implmklmpinompi" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_blas_implmklmpiopenmpi</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7705&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cp2k-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implmklmpiopenmpi" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_blas_implopenblasmpinompi</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7705&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cp2k-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implopenblasmpinompi" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_blas_implopenblasmpiopenmpi</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7705&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cp2k-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_blas_implopenblasmpiopenmpi" alt="variant">
-                </a>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </details>
+      <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7705&branchName=main">
+        <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/cp2k-feedstock?branchName=main">
+      </a>
     </td>
   </tr>
 </table>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 # Define build matrix for MPI vs. non-mpi
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% if mpi == 'nompi' %}
 # prioritize 'nompi' variant via build number
 {% set build = build + 1000 %}
@@ -37,6 +37,7 @@ build:
   #                   descb, beta, c, i_c, j_c, descc)
   # (specific to scalapack MKL and tested as failing for MKL 2019 until 2024
   skip: true  # [mpi == 'openmpi' and blas_impl == 'mkl']
+  noarch: python
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Due to the python 3.10 install, the conda package currently requires python 3.10 to be installed. Even though there are some python files in the source tree, I don't think there is a python dependency here. If there is and this package should also provide python support, we need to start with a large matrix build.