### PR TITLE
Add dependencies hdf5, plumed and trexio

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,10 +20,6 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '14'
-openblas:
-- 0.3.*
-openmpi:
-- '5'
 target_platform:
 - linux-64
 zip_keys:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,11 +13,14 @@ cmake -B build -S . \
   -DCP2K_USE_EVERYTHING="OFF" \
   -DCP2K_USE_ELPA="ON" \
   -DCP2K_USE_FFTW3="ON" \
+  -DCP2K_USE_HDF5="ON" \
   -DCP2K_USE_LIBINT2="ON" \
   -DCP2K_USE_LIBXC="ON" \
   -DCP2K_USE_MPI="ON" \
   -DCP2K_USE_MPI_F08="ON" \
-  -DCP2K_USE_SPGLIB="ON"
+  -DCP2K_USE_PLUMED="ON" \
+  -DCP2K_USE_SPGLIB="ON" \
+  -DCP2K_USE_TREXIO="ON"
 cmake --build build --parallel "${CPU_COUNT}"
 cmake --install build
 ln -sf cp2k.psmp "${PREFIX}/bin/cp2k.popt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 4364c74bcffaa474bc234e11686b09550e4d06932acf2147a341e4f7679dd88e
 
 build:
-  number: 2
+  number: 3
   skip: true  # [not linux]
 
 requirements:
@@ -30,13 +30,16 @@ requirements:
     - dbcsr >=2.9.0
     - "elpa >=2024.05.001 *openmpi_*"
     - "fftw >=3.3.10 *openmpi_*"
+    - hdf5 ~=1.14
     - libint >=2.6.0
     - libint-fortran-devel >=2.6.0
     - "libxc >=7.0.0 *cpu_*"
     - "openblas >=0.3.30 *openmp_*"
     - openmpi >=5.0.8
+    - "plumed >=2.9.2 *openmpi_*"
     - scalapack >=2.2.0
-    - spglib >=2.5.0
+    - spglib >=2.5
+    - trexio >2.6
   run:
     - "openblas >=0.3.30 *openmp_*"
 


### PR DESCRIPTION
MNT: Re-rendered with conda-smithy 3.60.0 and conda-forge-pinning 2026.04.17.03.21.26

- Add dependencies hdf5, plumed and trexio to build
- Bump build number to 3

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
